### PR TITLE
Fix links to headers

### DIFF
--- a/build/engines.js
+++ b/build/engines.js
@@ -31,10 +31,10 @@ const markdownEngines = {
       },
     })
     .use(mAnchor, {
+      slugify,
       permalink: mAnchor.permalink.ariaHidden({
         class: 'header-link',
         symbol: '<img src="/images/svg/paragraph.svg">',
-        renderHref: slugify,
       }),
     })
     .use(require('./lib/markdown-raw-html'), { debug: false }),


### PR DESCRIPTION
On, let's say https://curvyandtrans.com/p/81A28C/baby-trans-archetypes, the header "The Timid:" has ID "the-timid%3A", but the link next to it points to "the-timidpercent3a". This PR changes both the ID to "the-timid" (which I presume is the intended behavior), and the link to "#the-timid".

See also: https://github.com/GenderDysphoria/GenderDysphoria.fyi/issues/144